### PR TITLE
use waitUntil in nextjs examples

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -9,6 +9,7 @@ export const runtime = 'nodejs';
 
 export const dynamic = 'force-dynamic';
 
+import { waitUntil } from '@vercel/functions';
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 
@@ -23,12 +24,15 @@ const ratelimit = new Ratelimit({
 export async function GET(request: Request) {
 
   const identifier = "api";
-  const { success, limit, remaining } = await ratelimit.limit(identifier);
+  const { success, limit, remaining, pending } = await ratelimit.limit(identifier);
   const response = {
     success: success,
     limit: limit, 
     remaining: remaining
   }
+
+  // pending is a promise for handling the analytics submission
+  waitUntil(pending)
     
   if (!success) {
     return new Response(JSON.stringify(response), { status: 429 });
@@ -38,6 +42,8 @@ export async function GET(request: Request) {
 ```
 
 The `redis` parameter denotes the Upstash Redis instance we use. The `limiter` parameter denotes the algorithm used to limit requests. The `prefix` parameter is used when creating a key for entries in the Redis, allowing us to use a single Redis instance for different rate limiters. The `analytics` parameter denotes whether analytics will we sent to the Redis in order to use the Upstash Analytics dashboard.
+
+To limit the requests, we call `ratelimit.limit` method with an identifier `"api"`. This identifier could be the ip address or the user id in your use case. See [our documentation](https://upstash.com/docs/oss/sdks/ts/ratelimit/methods#limit) for more information.
 
 # Run locally
 

--- a/examples/nextjs/app/api/route.ts
+++ b/examples/nextjs/app/api/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'nodejs';
 
 export const dynamic = 'force-dynamic';
 
+import { waitUntil } from '@vercel/functions';
 import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 
@@ -10,17 +11,21 @@ const ratelimit = new Ratelimit({
   redis: Redis.fromEnv(),
   limiter: Ratelimit.slidingWindow(10, "10 s"),
   prefix: "@upstash/ratelimit",
+  analytics: true
 });
 
 export async function GET(request: Request) {
 
   const identifier = "api";
-  const { success, limit, remaining } = await ratelimit.limit(identifier);
+  const { success, limit, remaining, pending } = await ratelimit.limit(identifier);
   const response = {
     success: success,
     limit: limit, 
     remaining: remaining
   }
+
+  // pending is a promise for handling the analytics submission
+  waitUntil(pending)
     
   if (!success) {
     return new Response(JSON.stringify(response), { status: 429 });

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@upstash/ratelimit": "^1.1.3",
+    "@vercel/functions": "^1.0.2",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"

--- a/examples/vercel-edge/package.json
+++ b/examples/vercel-edge/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@upstash/ratelimit": "^1.1.3",
+    "@vercel/functions": "^1.0.2",
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
until recently, there was no way of using waitUntil in vercel edge. https://github.com/vercel/next.js/issues/50522

But now it is possible. Updating the nextjs and vercel-edge examples utilizing the waitUntil.