### PR TITLE
Hardcode script hash values and deprecate cacheScripts

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -22,13 +22,7 @@ export const safeEval = async (
     return await ctx.redis.evalsha(script.hash, keys, args)
   } catch (error) {
     if (`${error}`.includes("NOSCRIPT")) {
-      console.log(
-        "Upstash Ratelimit: Script to run wasn't found in"
-        + " redis db. Script will be loaded to Redis before continuing."
-      );
       const hash = await ctx.redis.scriptLoad(script.script)
-
-      console.log("Upstash Ratelimit: Script loaded successfully.");
       
       if (hash !== script.hash) {
         console.warn(

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -1,63 +1,44 @@
+import { ScriptInfo } from "./lua-scripts/hash";
 import { Context, RegionContext } from "./types"
 
-type ScriptKind = "limitHash" | "getRemainingHash" | "resetHash"
-
 /**
- * Loads the scripts to redises with SCRIPT LOAD if the first region context
- * doesn't have the kind of script hash in it. 
+ * Runs the specified script with EVALSHA using the scriptHash parameter.
+ * 
+ * If the EVALSHA fails, loads the script to redis and runs again with the
+ * hash returned from Redis.
  * 
  * @param ctx Regional or multi region context
- * @param script script to load
- * @param kind script kind
- */
-const setHash = async (
-  ctx: Context,
-  script: string,
-  kind: ScriptKind
-) => {
-  const regionContexts = "redis" in ctx ? [ctx] : ctx.regionContexts
-  const hashSample = regionContexts[0].scriptHashes[kind]
-  if (!hashSample) {
-    await Promise.all(regionContexts.map(async (context) => {
-      context.scriptHashes[kind] = await context.redis.scriptLoad(script)
-    }));
-  };
-}
-
-/**
- * Runds the specified script with EVALSHA if ctx.cacheScripts or EVAL
- * otherwise.
- * 
- * If the script is not found when EVALSHA is used, it submits the script
- * with LOAD SCRIPT, then calls EVALSHA again.
- * 
- * @param ctx Regional or multi region context
- * @param script script to run
- * @param kind script kind
- * @param keys 
- * @param args 
+ * @param script ScriptInfo of script to run. Contains the script and its hash
+ * @param keys eval keys
+ * @param args eval args
  */
 export const safeEval = async (
   ctx: RegionContext,
-  script: string,
-  kind: ScriptKind,
+  script: ScriptInfo,
   keys: any[],
   args: any[],
 ) => {
-  if (!ctx.cacheScripts) {
-    return await ctx.redis.eval(script, keys, args);
-  };
-
-  await setHash(ctx, script, kind);
   try {
-    return await ctx.redis.evalsha(ctx.scriptHashes[kind]!, keys, args)
+    return await ctx.redis.evalsha(script.hash, keys, args)
   } catch (error) {
     if (`${error}`.includes("NOSCRIPT")) {
-      console.log("Script with the expected hash was not found in redis db. It is probably flushed. Will load another scipt before continuing.");
-      ctx.scriptHashes[kind] = undefined;
-      await setHash(ctx, script, kind)
-      console.log("  New script successfully loaded.")
-      return await ctx.redis.evalsha(ctx.scriptHashes[kind]!, keys, args)
+      console.log(
+        "Upstash Ratelimit: Script to run wasn't found in"
+        + " redis db. Script will be loaded to Redis before continuing."
+      );
+      const hash = await ctx.redis.scriptLoad(script.script)
+
+      console.log("Upstash Ratelimit: Script loaded successfully.");
+      
+      if (hash !== script.hash) {
+        console.warn(
+          "Upstash Ratelimit: Expected hash and the hash received from Redis"
+          + " are different. Ratelimit will work as usual but performance will"
+          + " be reduced."
+        );
+      }
+      
+      return await ctx.redis.evalsha(hash, keys, args)
     }
     throw error;
   }

--- a/src/lua-scripts/hash.test.ts
+++ b/src/lua-scripts/hash.test.ts
@@ -10,8 +10,12 @@ describe("should use correct hash for lua scripts", () => {
     expect(hash).toBe(expectedHash)
   }
 
+  const algorithms = [
+    ...Object.entries(SCRIPTS.singleRegion), ...Object.entries(SCRIPTS.multiRegion)
+  ]
+
   // for each algorithm (fixedWindow, slidingWindow etc)
-  for (const [algorithm, scripts] of Object.entries(SCRIPTS)) {
+  for (const [algorithm, scripts] of algorithms) {
     describe(`${algorithm}`, () => {
       // for each method (limit & getRemaining)
       for (const [method, scriptInfo] of Object.entries(scripts)) {

--- a/src/lua-scripts/hash.test.ts
+++ b/src/lua-scripts/hash.test.ts
@@ -1,0 +1,28 @@
+import { Redis } from "@upstash/redis";
+import { describe, expect, test } from "bun:test";
+import { RESET_SCRIPT, SCRIPTS } from "./hash";
+
+describe("should use correct hash for lua scripts", () => {
+  const redis = Redis.fromEnv();
+
+  const validateHash = async (script: string, expectedHash: string) => {
+    const hash = await redis.scriptLoad(script)
+    expect(hash).toBe(expectedHash)
+  }
+
+  // for each algorithm (fixedWindow, slidingWindow etc)
+  for (const [algorithm, scripts] of Object.entries(SCRIPTS)) {
+    describe(`${algorithm}`, () => {
+      // for each method (limit & getRemaining)
+      for (const [method, scriptInfo] of Object.entries(scripts)) {
+        test(method, async () => {
+          await validateHash(scriptInfo.script, scriptInfo.hash)
+        })
+      }
+    })
+  }
+
+  test("reset script", async () => {
+    await validateHash(RESET_SCRIPT.script, RESET_SCRIPT.hash)
+  })
+})

--- a/src/lua-scripts/hash.ts
+++ b/src/lua-scripts/hash.ts
@@ -1,0 +1,92 @@
+import * as Single from "./single"
+import * as Multi from "./multi"
+import { resetScript } from "./reset"
+
+export type ScriptInfo = {
+  script: string,
+  hash: string
+}
+
+type Algorithm = {
+  limit: ScriptInfo,
+  getRemaining: ScriptInfo,
+}
+
+type AlgorithmKind = 
+  | "fixedWindow"
+  | "slidingWindow"
+  | "tokenBucket"
+  | "cachedFixedWindow"
+  | "multiRegionFixedWindow"
+  | "multiRegionSlidingWindow";
+
+export const SCRIPTS: {[T in AlgorithmKind]: Algorithm} = {
+  /** SINGLE REGION */
+  fixedWindow: {
+    limit: {
+      script: Single.fixedWindowLimitScript,
+      hash: "b13943e359636db027ad280f1def143f02158c13"
+    },
+    getRemaining: {
+      script: Single.fixedWindowRemainingTokensScript,
+      hash: "8c4c341934502aee132643ffbe58ead3450e5208"
+    },
+  },
+  slidingWindow: {
+    limit: {
+      script: Single.slidingWindowLimitScript,
+      hash: "e1391e429b699c780eb0480350cd5b7280fd9213"
+    },
+    getRemaining: {
+      script: Single.slidingWindowRemainingTokensScript,
+      hash: "65a73ac5a05bf9712903bc304b77268980c1c417"
+    },
+  },
+  tokenBucket: {
+    limit: {
+      script: Single.tokenBucketLimitScript,
+      hash: "5bece90aeef8189a8cfd28995b479529e270b3c6"
+    },
+    getRemaining: {
+      script: Single.tokenBucketRemainingTokensScript,
+      hash: "a15be2bb1db2a15f7c82db06146f9d08983900d0"
+    },
+  },
+  cachedFixedWindow: {
+    limit: {
+      script: Single.cachedFixedWindowLimitScript,
+      hash: "c26b12703dd137939b9a69a3a9b18e906a2d940f"
+    },
+    getRemaining: {
+      script: Single.cachedFixedWindowRemainingTokenScript,
+      hash: "8e8f222ccae68b595ee6e3f3bf2199629a62b91a"
+    },
+  },
+  /** MULTI REGION */
+  multiRegionFixedWindow: {
+    limit: {
+      script: Multi.fixedWindowLimitScript,
+      hash: "a8c14f3835aa87bd70e5e2116081b81664abcf5c"
+    },
+    getRemaining: {
+      script: Multi.fixedWindowRemainingTokensScript,
+      hash: "8ab8322d0ed5fe5ac8eb08f0c2e4557f1b4816fd"
+    },
+  },
+  multiRegionSlidingWindow: {
+    limit: {
+      script: Multi.slidingWindowLimitScript,
+      hash: "cb4fdc2575056df7c6d422764df0de3a08d6753b"
+    },
+    getRemaining: {
+      script: Multi.slidingWindowRemainingTokensScript,
+      hash: "558c9306b7ec54abb50747fe0b17e5d44bd24868"
+    },
+  },
+}
+
+/** COMMON */
+export const RESET_SCRIPT: ScriptInfo = {
+  script: resetScript,
+  hash: "54bd274ddc59fb3be0f42deee2f64322a10e2b50"
+}

--- a/src/lua-scripts/hash.ts
+++ b/src/lua-scripts/hash.ts
@@ -17,72 +17,75 @@ type AlgorithmKind =
   | "slidingWindow"
   | "tokenBucket"
   | "cachedFixedWindow"
-  | "multiRegionFixedWindow"
-  | "multiRegionSlidingWindow";
 
-export const SCRIPTS: {[T in AlgorithmKind]: Algorithm} = {
-  /** SINGLE REGION */
-  fixedWindow: {
-    limit: {
-      script: Single.fixedWindowLimitScript,
-      hash: "b13943e359636db027ad280f1def143f02158c13"
+export const SCRIPTS: {
+  singleRegion: Record<AlgorithmKind, Algorithm>,
+  multiRegion: Record<Exclude<AlgorithmKind, "tokenBucket" | "cachedFixedWindow">, Algorithm>,
+} = {
+  singleRegion: {
+    fixedWindow: {
+      limit: {
+        script: Single.fixedWindowLimitScript,
+        hash: "b13943e359636db027ad280f1def143f02158c13"
+      },
+      getRemaining: {
+        script: Single.fixedWindowRemainingTokensScript,
+        hash: "8c4c341934502aee132643ffbe58ead3450e5208"
+      },
     },
-    getRemaining: {
-      script: Single.fixedWindowRemainingTokensScript,
-      hash: "8c4c341934502aee132643ffbe58ead3450e5208"
+    slidingWindow: {
+      limit: {
+        script: Single.slidingWindowLimitScript,
+        hash: "e1391e429b699c780eb0480350cd5b7280fd9213"
+      },
+      getRemaining: {
+        script: Single.slidingWindowRemainingTokensScript,
+        hash: "65a73ac5a05bf9712903bc304b77268980c1c417"
+      },
     },
+    tokenBucket: {
+      limit: {
+        script: Single.tokenBucketLimitScript,
+        hash: "5bece90aeef8189a8cfd28995b479529e270b3c6"
+      },
+      getRemaining: {
+        script: Single.tokenBucketRemainingTokensScript,
+        hash: "a15be2bb1db2a15f7c82db06146f9d08983900d0"
+      },
+    },
+    cachedFixedWindow: {
+      limit: {
+        script: Single.cachedFixedWindowLimitScript,
+        hash: "c26b12703dd137939b9a69a3a9b18e906a2d940f"
+      },
+      getRemaining: {
+        script: Single.cachedFixedWindowRemainingTokenScript,
+        hash: "8e8f222ccae68b595ee6e3f3bf2199629a62b91a"
+      },
+    }
   },
-  slidingWindow: {
-    limit: {
-      script: Single.slidingWindowLimitScript,
-      hash: "e1391e429b699c780eb0480350cd5b7280fd9213"
+  multiRegion: {
+    fixedWindow: {
+      limit: {
+        script: Multi.fixedWindowLimitScript,
+        hash: "a8c14f3835aa87bd70e5e2116081b81664abcf5c"
+      },
+      getRemaining: {
+        script: Multi.fixedWindowRemainingTokensScript,
+        hash: "8ab8322d0ed5fe5ac8eb08f0c2e4557f1b4816fd"
+      },
     },
-    getRemaining: {
-      script: Single.slidingWindowRemainingTokensScript,
-      hash: "65a73ac5a05bf9712903bc304b77268980c1c417"
+    slidingWindow: {
+      limit: {
+        script: Multi.slidingWindowLimitScript,
+        hash: "cb4fdc2575056df7c6d422764df0de3a08d6753b"
+      },
+      getRemaining: {
+        script: Multi.slidingWindowRemainingTokensScript,
+        hash: "558c9306b7ec54abb50747fe0b17e5d44bd24868"
+      },
     },
-  },
-  tokenBucket: {
-    limit: {
-      script: Single.tokenBucketLimitScript,
-      hash: "5bece90aeef8189a8cfd28995b479529e270b3c6"
-    },
-    getRemaining: {
-      script: Single.tokenBucketRemainingTokensScript,
-      hash: "a15be2bb1db2a15f7c82db06146f9d08983900d0"
-    },
-  },
-  cachedFixedWindow: {
-    limit: {
-      script: Single.cachedFixedWindowLimitScript,
-      hash: "c26b12703dd137939b9a69a3a9b18e906a2d940f"
-    },
-    getRemaining: {
-      script: Single.cachedFixedWindowRemainingTokenScript,
-      hash: "8e8f222ccae68b595ee6e3f3bf2199629a62b91a"
-    },
-  },
-  /** MULTI REGION */
-  multiRegionFixedWindow: {
-    limit: {
-      script: Multi.fixedWindowLimitScript,
-      hash: "a8c14f3835aa87bd70e5e2116081b81664abcf5c"
-    },
-    getRemaining: {
-      script: Multi.fixedWindowRemainingTokensScript,
-      hash: "8ab8322d0ed5fe5ac8eb08f0c2e4557f1b4816fd"
-    },
-  },
-  multiRegionSlidingWindow: {
-    limit: {
-      script: Multi.slidingWindowLimitScript,
-      hash: "cb4fdc2575056df7c6d422764df0de3a08d6753b"
-    },
-    getRemaining: {
-      script: Multi.slidingWindowRemainingTokensScript,
-      hash: "558c9306b7ec54abb50747fe0b17e5d44bd24868"
-    },
-  },
+  }
 }
 
 /** COMMON */

--- a/src/multi.ts
+++ b/src/multi.ts
@@ -177,7 +177,7 @@ export class MultiRegionRatelimit extends Ratelimit<MultiRegionContext> {
           redis: regionContext.redis,
           request: safeEval(
             regionContext,
-            SCRIPTS.multiRegionFixedWindow.limit,
+            SCRIPTS.multiRegion.fixedWindow.limit,
             [key],
             [requestId, windowDuration, incrementBy],
           ) as Promise<string[]>,
@@ -282,7 +282,7 @@ export class MultiRegionRatelimit extends Ratelimit<MultiRegionContext> {
           redis: regionContext.redis,
           request: safeEval(
             regionContext,
-            SCRIPTS.multiRegionFixedWindow.getRemaining,
+            SCRIPTS.multiRegion.fixedWindow.getRemaining,
             [key],
             [null]
           ) as Promise<string[]>,
@@ -381,7 +381,7 @@ export class MultiRegionRatelimit extends Ratelimit<MultiRegionContext> {
           redis: regionContext.redis,
           request: safeEval(
             regionContext,
-            SCRIPTS.multiRegionSlidingWindow.limit,
+            SCRIPTS.multiRegion.slidingWindow.limit,
             [currentKey, previousKey],
             [tokens, now, windowDuration, requestId, incrementBy],
             // lua seems to return `1` for true and `null` for false
@@ -503,7 +503,7 @@ export class MultiRegionRatelimit extends Ratelimit<MultiRegionContext> {
           redis: regionContext.redis,
           request: safeEval(
             regionContext,
-            SCRIPTS.multiRegionSlidingWindow.getRemaining,
+            SCRIPTS.multiRegion.slidingWindow.getRemaining,
             [currentKey, previousKey],
             [now, windowSize],
             // lua seems to return `1` for true and `null` for false

--- a/src/single.ts
+++ b/src/single.ts
@@ -183,7 +183,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const usedTokensAfterUpdate = await safeEval(
           ctx,
-          SCRIPTS.fixedWindow.limit,
+          SCRIPTS.singleRegion.fixedWindow.limit,
           [key],
           [windowDuration, incrementBy],
         ) as number;
@@ -211,7 +211,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const usedTokens = await safeEval(
           ctx,
-          SCRIPTS.fixedWindow.getRemaining,
+          SCRIPTS.singleRegion.fixedWindow.getRemaining,
           [key],
           [null],
         ) as number;
@@ -291,7 +291,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const remainingTokens = await safeEval(
           ctx,
-          SCRIPTS.slidingWindow.limit,
+          SCRIPTS.singleRegion.slidingWindow.limit,
           [currentKey, previousKey],
           [tokens, now, windowSize, incrementBy],
         ) as number;
@@ -319,7 +319,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const usedTokens = await safeEval(
           ctx,
-          SCRIPTS.slidingWindow.getRemaining,
+          SCRIPTS.singleRegion.slidingWindow.getRemaining,
           [currentKey, previousKey],
           [now, windowSize],
         ) as number;
@@ -399,7 +399,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const [remaining, reset] = await safeEval(
           ctx,
-          SCRIPTS.tokenBucket.limit,
+          SCRIPTS.singleRegion.tokenBucket.limit,
           [identifier],
           [maxTokens, intervalDuration, refillRate, now, incrementBy],
         ) as [number, number];
@@ -421,7 +421,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const [remainingTokens, refilledAt] = await safeEval(
           ctx,
-          SCRIPTS.tokenBucket.getRemaining,
+          SCRIPTS.singleRegion.tokenBucket.getRemaining,
           [identifier],
           [maxTokens],
         ) as [number, number];
@@ -503,7 +503,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         const pending = success
             ? safeEval(
               ctx,
-              SCRIPTS.cachedFixedWindow.limit,
+              SCRIPTS.singleRegion.cachedFixedWindow.limit,
               [key],
               [windowDuration, incrementBy]
             )
@@ -520,7 +520,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const usedTokensAfterUpdate = await safeEval(
           ctx,
-          SCRIPTS.cachedFixedWindow.limit,
+          SCRIPTS.singleRegion.cachedFixedWindow.limit,
           [key],
           [windowDuration, incrementBy]
         ) as number;
@@ -554,7 +554,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
 
         const usedTokens = await safeEval(
           ctx,
-          SCRIPTS.cachedFixedWindow.getRemaining,
+          SCRIPTS.singleRegion.cachedFixedWindow.getRemaining,
           [key],
           [null],
         ) as number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,6 @@ export interface EphemeralCache {
 export type RegionContext = {
   redis: Redis;
   cache?: EphemeralCache,
-  scriptHashes: {
-    limitHash?: string,
-    getRemainingHash?: string,
-    resetHash?: string
-  },
-  cacheScripts: boolean,
 };
 export type MultiRegionContext = { regionContexts: Omit<RegionContext[], "cache">; cache?: EphemeralCache };
 


### PR DESCRIPTION
Previously, we had the cacheScripts parameter which allowed us to define the script running behavior of the sdk. The two options were:
1. `cacheScripts: true` (defaul): load the script to redis on cold start. In the other runs, use the hash with EVALSHA command. Resulted in two round trips in cold start.
2.`cacheScripts: false`: simply send the script with EVAL command. More bandwidth.

Now, we deprecate the cacheScripts parameter. It no longer has any affect. We also change the two behaviors:
- We hardcode the hash values to the sdk.
- We call redis with the hash values in cold/hot starts.
- If the EVALSHA fails because the script is missing at redis, we load the script and continue.