### PR TITLE
Optimized sliding-window

### DIFF
--- a/src/lua-scripts/hash.ts
+++ b/src/lua-scripts/hash.ts
@@ -36,11 +36,11 @@ export const SCRIPTS: {
     slidingWindow: {
       limit: {
         script: Single.slidingWindowLimitScript,
-        hash: "e1391e429b699c780eb0480350cd5b7280fd9213"
+        hash: "20408d957f9eabcc56b113f37785bbbbd301329c"
       },
       getRemaining: {
         script: Single.slidingWindowRemainingTokensScript,
-        hash: "65a73ac5a05bf9712903bc304b77268980c1c417"
+        hash: "5584aba50ee1821800228a532bec593cd08b7022"
       },
     },
     tokenBucket: {


### PR DESCRIPTION
Implemented the sliding-window ratelimiter in a more efficient way, requiring **less number of commands**. The new **command count matrix** is: 
| Cache Result |   Algorithm State  | Command Count |       Command      |
|:------------:|:------------------:|:-------------:|:------------------:|
|   Hit/Miss   |        First       |       3       |  EVAL, INCRBY, SET |
|   Hit/Miss   |    Intermediate    |       2       |    EVAL, INCRBY    |
|     Miss     | First Rate-Limited |       3       |  EVAL, INCRBY, SET |
|     Miss     |    Rate-Limited    |       2       |    EVAL, INCRBY    |
|      Hit     |    Rate-Limited    |       0       | *utilized cache* |

So, for most cases (i.e. Intermediate state), **the proposed implementation requires half (2/4) of the [number of commands required by the existing implementation](https://upstash.com/docs/redis/sdks/ratelimit-ts/costs#sliding-window)**.

Other comparisons
=================

|  | Proposed | Existing |
|:---:|:---:|:---:|
| Memory/Storage | 64-bit: Single integer encodes #requests from current & previous window | 2x64-bit: Uses 2 separate integers|
| Key reuse / Key-space size | First request in every window persists key for next window too. Smaller key space: Key is mapped to identifier only. | Keys don't live much beyond 2 windows. Larger key space: Key is mapped to identifier and timestamp. |
| Resetting used tokens | Fast [O(1)], requires single command: DEL | Slow [O(N)], requires multiple commands: SCAN, DEL |
| Stale key TTL | TTL = 2 * window, if last window doesn't see a request (i.e. expires soon when unused) | TTL = 2 * window + 1 second, (i.e. lingers) |
| Cache miss overhead | Once ratelimit is hit, returns early for all further requests in that window | Executes similar computations for all requests in a window |